### PR TITLE
V1.0.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 if the second number of version is even or 0 then it is a stable else a unstable release
 
-# v1.0.0
+# v1.0.1 (2.12.2013)
++ fix __compareObjSync/build with default values in schema which arent defined in factory
++ err object should return null instead of false
++ TypeError: Cannot call method 'create' of undefined. this.model wasnt defined in build callback
++ fix _compareObjSync should iterate through passed obj not mObj
+
+# v1.0.0 (1.12.2013)
 + mongoose functions, example instead of factory.model.find(), now factory.find()
 + default values for params
 + support for basic objects not only factory objects
@@ -9,7 +15,7 @@ if the second number of version is even or 0 then it is a stable else a unstable
 + Api
 + History
 
-# v0.0.2
+# v0.0.2 (21.11.2013)
 + mangosta key operators start with a $ 
 + $child support for factory
 + factory is build on build
@@ -18,5 +24,5 @@ if the second number of version is even or 0 then it is a stable else a unstable
 + multidoc creation with factory
 + renamed project to mangosta
 
-# v0.0.1
+# v0.0.1 (16.11.2013)
 + basic factory building and creation

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ factory = require("./factories/test_factory.js");
 factory.create(obj, callback)
 factory.build(obj, callback)
 
-callback = function(err, docs) {} // if single document return object else Array Object
+// if single document return object else Array Object
+// create return same param as model.create
+callback = function(err, docs) {}
 
 obj =
   {
@@ -90,12 +92,16 @@ obj =
     ]
   };;
 
+// if you wish you can access the model directly by factory.model
+
 // string methods
 // just include them in the value
 // please visit the strgMethods module to see what you can do
 // https://github.com/doodzik/strg_methods
 
 ```
+
+or to see more examples look at the testfile
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mangosta",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Mongoose fixtures library inspired by factory_girl",
   "main": "index.js",
   "keywords":

--- a/test/index.js
+++ b/test/index.js
@@ -221,7 +221,7 @@ describe('Factory', function(){
   describe('when _compareObjSync', function(){
     describe('when Obj factory', function(){
       it("returns false",function(){
-        factoryObj._compareObjSync({hola: "fas", type:"avr"}, {}).should.be.false;
+        (factoryObj._compareObjSync({hola: "fas", type:"avr"}, {}) == null).should.be.true;
       });
     });
     describe('when factory', function(){
@@ -235,11 +235,10 @@ describe('Factory', function(){
         });
       });
       describe('when mObj keys different then obj keys', function(){
-        it("returns false",function(){
+        it("returns null",function(){
           var mObj, err;
           mObj = new factory.model({    firstName: "d00d", lastName: "111", addr: "isabela", type: 0});
-          err = factory._compareObjSync(mObj, {firstName: "d00d", lastName: "111", addr: "isabela", type: 0})
-          err.should.be.false;
+          (factory._compareObjSync(mObj, {firstName: "d00d", lastName: "111", addr: "isabela", type: 0}) == null).should.be.true;
         });
       });
     });


### PR DESCRIPTION
- fix __compareObjSync/build with default values in schema which arent defined in factory
- err object should return null instead of false
- TypeError: Cannot call method 'create' of undefined. this.model wasnt defined in build callback
- fix _compareObjSync should iterate through passed obj not mObj
